### PR TITLE
Add MapLibre PWA WebSocket template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# pwa-maplibre
+# PWA MapLibre WebSocket Örneği
+
+Bu depo, MapLibre harita kütüphanesi ile Progressive Web App (PWA) ve WebSocket temellerini bir araya getiren basit bir başlangıç şablonu içerir.
+
+## Kurulum
+
+1. `public` klasörünü bir statik sunucuda barındırın (örneğin `serve` ya da herhangi bir HTTP sunucusu).
+2. WebSocket sunucusu olarak `ws://localhost:8080` adresinde çalışan basit bir sunucu oluşturun. Sunucu, `{ "lng": <number>, "lat": <number> }` formatında koordinatlar gönderebilir.
+3. Uygulamayı tarayıcıda açtığınızda harita yüklenecek ve WebSocket üzerinden gelen koordinatlar harita üzerinde işaretlenmeye başlayacaktır.
+
+## Dosya Yapısı
+
+- `public/index.html`: Uygulamanın ana sayfası ve MapLibre entegrasyonu.
+- `public/main.js`: Harita tanımları, PWA servis çalışanı kaydı ve WebSocket bağlantısı.
+- `public/service-worker.js`: Basit önbellekleme yapısı sağlayan servis çalışanı.
+- `public/manifest.json`: PWA yapılandırması.
+- `public/icons/`: PWA ikonlarının bulunduğu klasör (örnek ikonlar placeholders olarak eklenmiştir).
+
+## Kullanım
+
+Sunucuları başlattıktan sonra sayfayı ziyaret edin ve WebSocket üzerinden gelen koordinatların haritada işaretlendiğini gözlemleyin. Bu şablon, PWA ve WebSocket kullanımı hakkında temel bir fikir vermek için hazırlanmıştır ve gerçek projelerde özelleştirilebilir.

--- a/public/icons/icon-192.png
+++ b/public/icons/icon-192.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/icons/icon-512.png
+++ b/public/icons/icon-512.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PWA MapLibre WebSocket Örneği</title>
+  <link href="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.css" rel="stylesheet" />
+  <link rel="manifest" href="manifest.json" />
+  <style>
+    body, html { margin: 0; height: 100%; }
+    #map { width: 100%; height: 100%; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+
+  <script src="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,27 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}
+
+const map = new maplibregl.Map({
+  container: 'map',
+  style: 'https://demotiles.maplibre.org/style.json',
+  center: [29.0, 41.0],
+  zoom: 5
+});
+
+let ws;
+function initWebSocket() {
+  ws = new WebSocket('ws://localhost:8080');
+  ws.onopen = () => console.log('WebSocket connected');
+  ws.onmessage = event => {
+    const data = JSON.parse(event.data);
+    if (data.lng && data.lat) {
+      new maplibregl.Marker().setLngLat([data.lng, data.lat]).addTo(map);
+    }
+  };
+  ws.onclose = () => setTimeout(initWebSocket, 1000);
+}
+
+initWebSocket();

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "PWA MapLibre WebSocket Örneği",
+  "short_name": "MapLibrePWA",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1976d2",
+  "icons": [
+    {
+      "src": "icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,21 @@
+const CACHE_NAME = 'maplibre-pwa-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/main.js',
+  '/manifest.json',
+  'https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js',
+  'https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.css'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- create a `public` directory with a simple PWA setup
- integrate MapLibre map viewer and WebSocket example
- document how to run the template in Turkish

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cfce10bcc832880a88a07d89379b5